### PR TITLE
Add profile messaging modal and endpoint

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -11,6 +11,7 @@ const profileRoutes = require('./routes/profile');
 const authRoutes = require('./routes/auth');
 const dashboardRoutes = require('./routes/dashboard');
 const notificationRoutes = require('./routes/notifications');
+const messageRoutes = require('./routes/messages');
 const PageController = require('./controllers/pageController');
 const DashboardController = require('./controllers/dashboardController');
 const ProfileController = require('./controllers/profileController');
@@ -99,6 +100,7 @@ app.use('/api', apiRoutes);
 app.use('/api/accounts', accountRoutes);
 app.use('/api/profiles', profileRoutes);
 app.use('/api/notifications', notificationRoutes);
+app.use('/api/messages', messageRoutes);
 
 // Handle GET requests to API endpoints (redirect to appropriate pages)
 // Note: POST requests to these endpoints work normally for form submissions

--- a/backend/controllers/messageController.js
+++ b/backend/controllers/messageController.js
@@ -1,0 +1,88 @@
+const fs = require('fs');
+const { Notification, Profile } = require('../models');
+
+const MAX_TOTAL_BYTES = 5 * 1024 * 1024;
+
+const formatPreview = (body) => {
+    if (!body) return '';
+    const condensed = body.replace(/\s+/g, ' ').trim();
+    return condensed.length > 140 ? `${condensed.slice(0, 140)}…` : condensed;
+};
+
+const cleanupFiles = (files = []) => {
+    files.forEach((file) => {
+        try {
+            fs.unlinkSync(file.path);
+        } catch (error) {
+            // Best-effort cleanup
+            console.error('Failed to cleanup upload:', error.message);
+        }
+    });
+};
+
+class MessageController {
+    static async sendToProfile(req, res) {
+        try {
+            const { subject, body, profileSlug } = req.body;
+            const senderAccountId = req.user?.id;
+
+            if (!senderAccountId) {
+                cleanupFiles(req.files);
+                return res.status(401).json({ error: 'Authentication required to send messages' });
+            }
+
+            if (!subject || !body || !profileSlug) {
+                cleanupFiles(req.files);
+                return res.status(400).json({ error: 'Subject, message body, and profile are required' });
+            }
+
+            const profile = await Profile.findOne({ where: { slug: profileSlug } });
+            if (!profile) {
+                cleanupFiles(req.files);
+                return res.status(404).json({ error: 'The recipient profile could not be found' });
+            }
+
+            const attachments = Array.isArray(req.files) ? req.files : [];
+            const totalSize = attachments.reduce((sum, file) => sum + file.size, 0);
+
+            if (totalSize > MAX_TOTAL_BYTES) {
+                cleanupFiles(attachments);
+                return res.status(400).json({ error: 'Attachments cannot exceed 5 MB in total' });
+            }
+
+            const attachmentMetadata = attachments.map((file) => ({
+                originalName: file.originalname,
+                fileName: file.filename,
+                size: file.size,
+                mimeType: file.mimetype,
+                url: `/uploads/messages/${file.filename}`,
+            }));
+
+            const notification = await Notification.create({
+                accountId: profile.accountId,
+                title: subject,
+                body,
+                category: 'external',
+                sender: req.user?.username || 'CritXChange member',
+                previewText: formatPreview(body),
+                metadata: {
+                    attachments: attachmentMetadata,
+                    fromAccountId: senderAccountId,
+                    fromUsername: req.user?.username || 'Member',
+                    profileSlug,
+                },
+            });
+
+            return res.status(201).json({
+                notification,
+                message: 'Your message has been sent to the profile owner.',
+            });
+        } catch (error) {
+            console.error('Error sending profile message:', error);
+            cleanupFiles(req.files);
+            return res.status(500).json({ error: 'Unable to send your message right now' });
+        }
+    }
+}
+
+module.exports = MessageController;

--- a/backend/public/css/style.css
+++ b/backend/public/css/style.css
@@ -1087,6 +1087,47 @@ body {
     border: 1px solid var(--border-color);
 }
 
+.message-attachments {
+    background: var(--bg-primary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    padding: var(--spacing-md);
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.message-attachments ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.message-attachments li {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.75rem;
+    align-items: center;
+}
+
+.message-attachments a {
+    color: var(--primary-color);
+    text-decoration: none;
+    word-break: break-word;
+}
+
+.message-attachments a:hover {
+    text-decoration: underline;
+}
+
+.attachment-size {
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+}
+
 .message-actions {
     display: flex;
     gap: var(--spacing-sm);
@@ -1380,6 +1421,73 @@ body {
     border: 1px dashed rgba(255, 255, 255, 0.2);
     padding: 1.5rem;
     border-radius: 1rem;
+}
+
+.profile-actions {
+    margin-top: 1.5rem;
+}
+
+.profile-actions .btn-primary {
+    padding: 0.85rem 1.4rem;
+    font-weight: 700;
+}
+
+.modal {
+    position: fixed;
+    inset: 0;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.modal.open {
+    display: flex;
+}
+
+.modal__overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(2px);
+}
+
+.modal__content {
+    position: relative;
+    background: var(--bg-secondary);
+    padding: 1.5rem;
+    border-radius: 1rem;
+    border: 1px solid var(--border-color);
+    width: min(720px, 95%);
+    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.35);
+    z-index: 1;
+}
+
+.modal__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 1rem;
+    gap: 1rem;
+}
+
+.modal__close {
+    background: transparent;
+    color: #fff;
+    border: none;
+    font-size: 1.6rem;
+    cursor: pointer;
+    line-height: 1;
+}
+
+.modal__actions {
+    display: flex;
+    gap: 0.75rem;
+    justify-content: flex-end;
+}
+
+.no-scroll {
+    overflow: hidden;
 }
 
 .service-chip {

--- a/backend/public/js/account-admin.js
+++ b/backend/public/js/account-admin.js
@@ -290,6 +290,25 @@ const renderReplies = (metadata = {}) => {
     `;
 };
 
+const renderAttachments = (metadata = {}) => {
+    const attachments = Array.isArray(metadata.attachments) ? metadata.attachments : [];
+    if (!attachments.length) return '';
+
+    return `
+        <div class="message-attachments">
+            <p class="eyebrow">Attachments</p>
+            <ul>
+                ${attachments.map((file) => `
+                    <li>
+                        <a href="${file.url}" target="_blank" rel="noopener noreferrer">${file.originalName || file.fileName}</a>
+                        <span class="attachment-size">${file.size ? `${(file.size / 1024).toFixed(1)} KB` : ''}</span>
+                    </li>
+                `).join('')}
+            </ul>
+        </div>
+    `;
+};
+
 const renderNotificationDetail = (notification) => {
     const detail = document.getElementById('notificationDetail');
     if (!detail) return;
@@ -320,6 +339,7 @@ const renderNotificationDetail = (notification) => {
         <div class="message-body">
             <p>${notification.body}</p>
         </div>
+        ${renderAttachments(notification.metadata)}
         <div class="message-actions">
             <button type="button" class="btn-primary" id="markReadToggle">
                 ${notification.isRead ? 'Mark as unread' : 'Mark as read'}

--- a/backend/public/js/profile-public.js
+++ b/backend/public/js/profile-public.js
@@ -1,0 +1,160 @@
+const MAX_TOTAL_BYTES = 5 * 1024 * 1024;
+
+const getTokenFromStorage = () => {
+    if (typeof window === 'undefined') return null;
+    return localStorage.getItem('token') || document.cookie.split('; ').find((row) => row.startsWith('token='))?.split('=')[1] || null;
+};
+
+const formatBytes = (bytes) => {
+    if (bytes < 1024) return `${bytes} B`;
+    const kb = bytes / 1024;
+    if (kb < 1024) return `${kb.toFixed(1)} KB`;
+    return `${(kb / 1024).toFixed(1)} MB`;
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+    const modal = document.getElementById('messageModal');
+    const openBtn = document.getElementById('contactProfileBtn');
+    const closeBtn = document.getElementById('closeMessageModal');
+    const cancelBtn = document.getElementById('cancelMessageModal');
+    const overlay = document.getElementById('messageModalOverlay');
+    const form = document.getElementById('profileMessageForm');
+    const attachmentsInput = document.getElementById('messageAttachments');
+    const attachmentStatus = document.getElementById('attachmentStatus');
+    const messageStatus = document.getElementById('messageStatus');
+    const submitBtn = form?.querySelector('button[type="submit"]');
+
+    const setStatus = (element, message, isError = false) => {
+        if (!element) return;
+        element.textContent = message;
+        element.classList.remove('error', 'success');
+        if (message) {
+            element.classList.add(isError ? 'error' : 'success');
+        }
+    };
+
+    const toggleModal = (isOpen) => {
+        if (!modal) return;
+        modal.classList.toggle('open', isOpen);
+        modal.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
+        document.body.classList.toggle('no-scroll', isOpen);
+        if (isOpen) {
+            document.getElementById('messageSubject')?.focus();
+        }
+    };
+
+    const resetForm = () => {
+        if (!form) return;
+        form.reset();
+        setStatus(attachmentStatus, '');
+        setStatus(messageStatus, '');
+    };
+
+    const validateAttachments = () => {
+        if (!attachmentsInput || !attachmentStatus) return true;
+        const files = Array.from(attachmentsInput.files || []);
+        if (!files.length) {
+            setStatus(attachmentStatus, '');
+            return true;
+        }
+
+        const totalBytes = files.reduce((sum, file) => sum + file.size, 0);
+        if (totalBytes > MAX_TOTAL_BYTES) {
+            setStatus(attachmentStatus, `Attachments are too large (${formatBytes(totalBytes)}). The maximum total size is 5 MB.`, true);
+            return false;
+        }
+
+        const fileList = files.map((file) => `${file.name} (${formatBytes(file.size)})`).join(', ');
+        setStatus(attachmentStatus, `Attached: ${fileList}`);
+        return true;
+    };
+
+    const handleSubmit = async (event) => {
+        event.preventDefault();
+        if (!form) return;
+        const token = getTokenFromStorage();
+        if (!token) {
+            setStatus(messageStatus, 'Please log in again to send a message.', true);
+            return;
+        }
+
+        const isValidAttachments = validateAttachments();
+        if (!isValidAttachments) return;
+
+        const subject = form.subject.value.trim();
+        const body = form.body.value.trim();
+
+        if (!subject || !body) {
+            setStatus(messageStatus, 'Please add both a subject and message.', true);
+            return;
+        }
+
+        const formData = new FormData();
+        formData.append('subject', subject);
+        formData.append('body', body);
+        formData.append('profileSlug', form.dataset.profileSlug || '');
+
+        Array.from(attachmentsInput?.files || []).forEach((file) => {
+            formData.append('attachments', file);
+        });
+
+        setStatus(messageStatus, 'Sending your message…');
+        if (submitBtn) submitBtn.disabled = true;
+
+        try {
+            const response = await fetch('/api/messages', {
+                method: 'POST',
+                headers: { Authorization: `Bearer ${token}` },
+                body: formData,
+            });
+
+            const payload = await response.json();
+            if (!response.ok) {
+                throw new Error(payload?.error || 'Unable to send your message');
+            }
+
+            setStatus(messageStatus, payload?.message || 'Message sent successfully.', false);
+            setTimeout(() => {
+                toggleModal(false);
+                resetForm();
+            }, 600);
+        } catch (error) {
+            setStatus(messageStatus, error.message || 'Unable to send your message', true);
+        } finally {
+            if (submitBtn) submitBtn.disabled = false;
+        }
+    };
+
+    if (attachmentsInput) {
+        attachmentsInput.addEventListener('change', validateAttachments);
+    }
+
+    if (form) {
+        form.addEventListener('submit', handleSubmit);
+    }
+
+    if (openBtn) {
+        openBtn.addEventListener('click', () => toggleModal(true));
+    }
+
+    if (closeBtn) {
+        closeBtn.addEventListener('click', () => toggleModal(false));
+    }
+
+    if (cancelBtn) {
+        cancelBtn.addEventListener('click', () => {
+            resetForm();
+            toggleModal(false);
+        });
+    }
+
+    if (overlay) {
+        overlay.addEventListener('click', () => toggleModal(false));
+    }
+
+    document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && modal?.classList.contains('open')) {
+            toggleModal(false);
+        }
+    });
+});

--- a/backend/routes/messages.js
+++ b/backend/routes/messages.js
@@ -1,0 +1,65 @@
+const express = require('express');
+const fs = require('fs');
+const multer = require('multer');
+const path = require('path');
+const authenticateJWT = require('../middleware/auth');
+const MessageController = require('../controllers/messageController');
+
+const router = express.Router();
+
+const uploadDirectory = path.join(__dirname, '..', 'public', 'uploads', 'messages');
+if (!fs.existsSync(uploadDirectory)) {
+    fs.mkdirSync(uploadDirectory, { recursive: true });
+}
+
+const storage = multer.diskStorage({
+    destination: (_req, _file, cb) => {
+        cb(null, uploadDirectory);
+    },
+    filename: (req, file, cb) => {
+        const ext = path.extname(file.originalname) || '.bin';
+        cb(null, `${req.user?.id || 'message'}-${Date.now()}${ext}`);
+    },
+});
+
+const allowedTypes = [
+    'image/',
+    'text/',
+    'application/pdf',
+    'application/msword',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    'application/vnd.ms-excel',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'application/zip',
+];
+
+const fileFilter = (_req, file, cb) => {
+    const isAllowed = allowedTypes.some((type) => file.mimetype === type || file.mimetype.startsWith(type));
+    if (!isAllowed) {
+        cb(new Error('Unsupported file type. Please attach common documents or images.'));
+    } else {
+        cb(null, true);
+    }
+};
+
+const upload = multer({
+    storage,
+    fileFilter,
+    limits: {
+        fileSize: 5 * 1024 * 1024,
+        files: 5,
+    },
+});
+
+const uploadHandler = upload.array('attachments', 5);
+
+router.post('/', authenticateJWT, (req, res, next) => {
+    uploadHandler(req, res, (err) => {
+        if (err) {
+            return res.status(400).json({ error: err.message || 'Unable to process attachments' });
+        }
+        return MessageController.sendToProfile(req, res, next);
+    });
+});
+
+module.exports = router;

--- a/backend/views/components/profile-public-body.ejs
+++ b/backend/views/components/profile-public-body.ejs
@@ -26,6 +26,13 @@
                             </div>
                         <% } %>
                     </dl>
+                    <% if (user) { %>
+                        <div class="profile-actions">
+                            <button class="btn-primary" type="button" id="contactProfileBtn" data-profile-slug="<%= profile.slug %>">
+                                Send a message
+                            </button>
+                        </div>
+                    <% } %>
                 </div>
             </div>
 
@@ -46,4 +53,39 @@
             </section>
         <% } %>
     </div>
+
+    <% if (user) { %>
+        <div class="modal" id="messageModal" aria-hidden="true" role="dialog" aria-labelledby="messageModalTitle">
+            <div class="modal__overlay" id="messageModalOverlay"></div>
+            <div class="modal__content" role="document">
+                <div class="modal__header">
+                    <h2 id="messageModalTitle">Message <%= profile.displayName %></h2>
+                    <button class="modal__close" type="button" id="closeMessageModal" aria-label="Close message composer">×</button>
+                </div>
+                <form id="profileMessageForm" data-profile-slug="<%= profile.slug %>" enctype="multipart/form-data">
+                    <div class="form-group">
+                        <label for="messageSubject">Subject</label>
+                        <input type="text" id="messageSubject" name="subject" required maxlength="150" placeholder="Project inquiry or collaboration idea">
+                    </div>
+                    <div class="form-group">
+                        <label for="messageBody">Message</label>
+                        <textarea id="messageBody" name="body" rows="6" required placeholder="Share details about what you need and your timeline"></textarea>
+                    </div>
+                    <div class="form-group">
+                        <label for="messageAttachments">Attachments (optional)</label>
+                        <input type="file" id="messageAttachments" name="attachments" multiple aria-describedby="attachmentHint">
+                        <p class="helper-text" id="attachmentHint">You can attach documents or images. Maximum total size: 5 MB.</p>
+                        <p class="form-status" id="attachmentStatus" role="status" aria-live="polite"></p>
+                    </div>
+                    <div class="form-footer">
+                        <p class="form-status" id="messageStatus" role="status" aria-live="polite"></p>
+                        <div class="modal__actions">
+                            <button type="button" class="btn-ghost" id="cancelMessageModal">Cancel</button>
+                            <button type="submit" class="btn-primary">Send message</button>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    <% } %>
 </section>

--- a/backend/views/profile-public.ejs
+++ b/backend/views/profile-public.ejs
@@ -5,5 +5,6 @@
     user: typeof user !== 'undefined' ? user : null,
     profile: typeof profile !== 'undefined' ? profile : null,
     accountMeta: typeof accountMeta !== 'undefined' ? accountMeta : null,
-    notFound: typeof notFound !== 'undefined' ? notFound : false
+    notFound: typeof notFound !== 'undefined' ? notFound : false,
+    additionalScripts: '<script src="/js/profile-public.js" defer></script>'
 }) %>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.2
+      multer:
+        specifier: ^2.0.2
+        version: 2.0.2
       nodemailer:
         specifier: ^7.0.10
         version: 7.0.10
@@ -780,6 +783,9 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  append-field@1.0.0:
+    resolution: {integrity: sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==}
+
   aproba@2.1.0:
     resolution: {integrity: sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==}
 
@@ -920,6 +926,10 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
+  busboy@1.6.0:
+    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
+    engines: {node: '>=10.16.0'}
+
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -1033,6 +1043,10 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  concat-stream@2.0.0:
+    resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
+    engines: {'0': node >= 6.0}
 
   confusing-browser-globals@1.0.11:
     resolution: {integrity: sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==}
@@ -2241,6 +2255,10 @@ packages:
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
+  mkdirp@0.5.6:
+    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
+    hasBin: true
+
   mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
@@ -2260,6 +2278,10 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  multer@2.0.2:
+    resolution: {integrity: sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==}
+    engines: {node: '>= 10.16.0'}
 
   nanoid@3.3.7:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
@@ -2892,6 +2914,10 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
+  streamsearch@1.1.0:
+    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
+    engines: {node: '>=10.0.0'}
+
   string-length@4.0.2:
     resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
     engines: {node: '>=10'}
@@ -3044,6 +3070,9 @@ packages:
   typed-array-length@1.0.7:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
+
+  typedarray@0.0.6:
+    resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
   uid-safe@2.1.5:
     resolution: {integrity: sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==}
@@ -3946,6 +3975,8 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
+  append-field@1.0.0: {}
+
   aproba@2.1.0:
     optional: true
 
@@ -4149,6 +4180,10 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  busboy@1.6.0:
+    dependencies:
+      streamsearch: 1.1.0
+
   bytes@3.1.2: {}
 
   cacache@15.3.0:
@@ -4282,6 +4317,13 @@ snapshots:
   component-emitter@1.3.1: {}
 
   concat-map@0.0.1: {}
+
+  concat-stream@2.0.0:
+    dependencies:
+      buffer-from: 1.1.2
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      typedarray: 0.0.6
 
   confusing-browser-globals@1.0.11: {}
 
@@ -5822,6 +5864,10 @@ snapshots:
 
   mkdirp-classic@0.5.3: {}
 
+  mkdirp@0.5.6:
+    dependencies:
+      minimist: 1.2.8
+
   mkdirp@1.0.4: {}
 
   moment-timezone@0.5.45:
@@ -5835,6 +5881,16 @@ snapshots:
   ms@2.1.2: {}
 
   ms@2.1.3: {}
+
+  multer@2.0.2:
+    dependencies:
+      append-field: 1.0.0
+      busboy: 1.6.0
+      concat-stream: 2.0.0
+      mkdirp: 0.5.6
+      object-assign: 4.1.1
+      type-is: 1.6.18
+      xtend: 4.0.2
 
   nanoid@3.3.7: {}
 
@@ -6537,6 +6593,8 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
+  streamsearch@1.1.0: {}
+
   string-length@4.0.2:
     dependencies:
       char-regex: 1.0.2
@@ -6728,6 +6786,8 @@ snapshots:
       is-typed-array: 1.1.15
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
+
+  typedarray@0.0.6: {}
 
   uid-safe@2.1.5:
     dependencies:


### PR DESCRIPTION
## Summary
- add an authenticated messaging endpoint that delivers profile messages as notifications with attachment metadata and safeguards
- add a modal on public profile pages for signed-in users to compose messages with client-side size validation and file attachments
- surface attached files inside the account notification detail view and style the new composer experience

## Testing
- pnpm test -- --runInBand

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f21de3a248331a54363a2620c8f98)