### PR TITLE
Address Codex feedback: secure message bodies and attachments

### DIFF
--- a/backend/public/js/account-admin.js
+++ b/backend/public/js/account-admin.js
@@ -283,7 +283,7 @@ const renderReplies = (metadata = {}) => {
             ${replies.map((reply) => `
                 <div class="reply">
                     <small>${reply.sender || 'You'} · ${formatDateTime(reply.createdAt)}</small>
-                    <p>${reply.body}</p>
+                    <p>${escapeHtml(reply.body)}</p>
                 </div>
             `).join('')}
         </div>
@@ -307,6 +307,15 @@ const renderAttachments = (metadata = {}) => {
             </ul>
         </div>
     `;
+};
+
+const escapeHtml = (value = '') => {
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
 };
 
 const renderNotificationDetail = (notification) => {
@@ -337,7 +346,7 @@ const renderNotificationDetail = (notification) => {
         </div>
         <h3>${notification.title}</h3>
         <div class="message-body">
-            <p>${notification.body}</p>
+            <p>${escapeHtml(notification.body)}</p>
         </div>
         ${renderAttachments(notification.metadata)}
         <div class="message-actions">

--- a/backend/routes/messages.js
+++ b/backend/routes/messages.js
@@ -7,7 +7,7 @@ const MessageController = require('../controllers/messageController');
 
 const router = express.Router();
 
-const uploadDirectory = path.join(__dirname, '..', 'public', 'uploads', 'messages');
+const uploadDirectory = path.join(__dirname, '..', 'data', 'uploads', 'messages');
 if (!fs.existsSync(uploadDirectory)) {
     fs.mkdirSync(uploadDirectory, { recursive: true });
 }
@@ -61,5 +61,9 @@ router.post('/', authenticateJWT, (req, res, next) => {
         return MessageController.sendToProfile(req, res, next);
     });
 });
+
+router.get('/:notificationId/attachments/:fileName', authenticateJWT, (req, res) =>
+    MessageController.downloadAttachment(req, res, uploadDirectory),
+);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- escape notification and reply bodies before rendering in the account admin UI
- store message attachments outside of the public static directory and serve them through an authenticated download route
- generate secure attachment URLs tied to their notification for authorized recipients only

## Testing
- pnpm test -- --runInBand

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f4a2eb4708331ba8c515e576df93c)